### PR TITLE
Add pyspnego 0.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,9 @@ requirements:
     - python >=3.6
     - cryptography
     # Optional dependency, see https://github.com/jborean93/pyspnego#optional-requirements
-    - ruamel.yaml
+    # This package isn't included in SOW Packages list on s390x, 
+    # and ruamel.yaml isn't available on s390x
+    - ruamel.yaml  # [not s390x]
   # While pyspnego supports Kerberos authentication on Linux, 
   # it isn't included by default due to its reliance on system packages to be present.
   # For Kerberos authentication on Linux python-gssapi and pykrb5 can be installed 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,26 +11,32 @@ source:
   sha256: ccb8d9cea310f1715d5ed3d2d092db9bf50ff2762cf94a0dd9dfab7774a727fe
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv  # [not win]
+  entry_points:
+    - pyspnego-parse = spnego.__main__:main
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
-    - python  >=3.7
+    - python
     - cryptography
     - cython
     - pip
+    - setuptools
+    - wheel
   run:
-    - python  >=3.7
+    - python >=3.6
     - cryptography
+    # Optional dependency
     - ruamel.yaml
-  run_constrained:
-    - python-gssapi >=1.5.0  # [not win]
+  # While pyspnego supports Kerberos authentication on Linux, 
+  # it isn't included by default due to its reliance on system packages to be present.
+  # For Kerberos authentication on Linux python-gssapi and pykrb5 can be installed 
+  # to add extra features that do not come with the base package
+  #run_constrained:
+  #  - python-gssapi >=1.5.0  # [not win]
 
 test:
   imports:
@@ -46,7 +52,10 @@ about:
   home: https://github.com/jborean93/pyspnego
   summary: Windows Negotiate Authentication Client and Server
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/jborean93/pyspnego
+  doc_url: https://github.com/jborean93/pyspnego/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python >=3.6
     - cryptography
-    # Optional dependency
+    # Optional dependency, see https://github.com/jborean93/pyspnego#optional-requirements
     - ruamel.yaml
   # While pyspnego supports Kerberos authentication on Linux, 
   # it isn't included by default due to its reliance on system packages to be present.


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/jborean93/pyspnego/issues
Github releases:  https://github.com/jborean93/pyspnego/releases
Upstream license:  License file:  https://github.com/jborean93/pyspnego/blob/master/LICENSE
Upstream Changelog: https://github.com/jborean93/pyspnego/blob/main/CHANGELOG.md
Upstream setup file: https://github.com/jborean93/pyspnego/blob/v0.3.1/setup.py

The package pyspnego is mentioned inside the packages:
requests-kerberos |

Actions:
1. Update dependencies
2. Add missing packages: `setuptools`, `wheel`
3. Add comments about optional dependencies` ruamel.yaml`, `python-gssapi` and `pykrb5`
4. Add license_family
5. Add dev, doc ulrs
6. Add `entry_points: - pyspnego-parse = spnego.__main__:main`
7. Fix python in run
8. Skip `ruamel.yaml` on `s390x` because isn't available on that platform

Result:
- all-succeeded