### PR TITLE
Rebuild pyspnego 0.3.1 for python 3.10 support on ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ccb8d9cea310f1715d5ed3d2d092db9bf50ff2762cf94a0dd9dfab7774a727fe
 
 build:
-  number: 0
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv  # [not win]
   entry_points:
     - pyspnego-parse = spnego.__main__:main
@@ -56,8 +56,12 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  license_url: https://github.com/jborean93/pyspnego/blob/main/LICENSE
   dev_url: https://github.com/jborean93/pyspnego
   doc_url: https://github.com/jborean93/pyspnego/blob/main/README.md
+  description: |
+    Library to handle SPNEGO (Negotiate, NTLM, Kerberos) and CredSSP authentication. 
+    Also includes a packet parser that can be used to decode raw NTLM/SPNEGO/Kerberos tokens into a human readable format.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
To address the issue https://github.com/ContinuumIO/anaconda-issues/issues/13034

Actions:
1. Bump build number to 2 for consistency because now we have 0 and 1 for different python versions
2. Add license_url
3. Add a description